### PR TITLE
Fixed bug in extension check that stops PNGs being created.

### DIFF
--- a/src/android/Canvas2ImagePlugin.java
+++ b/src/android/Canvas2ImagePlugin.java
@@ -107,9 +107,14 @@ public class Canvas2ImagePlugin extends CordovaPlugin {
 			 * 2.2
 			 */
 			if (check >= 1) {
-				folder = Environment
-//					.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-					.getExternalStoragePublicDirectory(picfolder);
+				if (picfolder == Environment.DIRECTORY_PICTURES){
+					folder = Environment
+	//					.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+						.getExternalStoragePublicDirectory(picfolder);
+				}
+				else{
+					folder = new File(picfolder);
+				}
 				if(!folder.exists()) {
 					folder.mkdirs();
 				}

--- a/www/Canvas2ImagePlugin.js
+++ b/www/Canvas2ImagePlugin.js
@@ -17,7 +17,7 @@
         else if (typeof failureCallback != "function") {
             console.log("Canvas2ImagePlugin Error: failureCallback is not a function");
         }
-        else if ((fileExtension) && ((fileExtension.toLowerCase() != '.jpg') && (fileExtension.toLowerCase != '.png'))) {
+        else if ((fileExtension) && ((fileExtension.toLowerCase() != '.jpg') && (fileExtension.toLowerCase() != '.png'))) {
             console.log("Canvas2ImagePlugin Error: fileExtension must be '.jpg' or '.png'");
         }
         else {


### PR DESCRIPTION
PNG creation wasn't working as toLowerCase conversion on file extension check wasn't calling the function.

Changed
```
fileExtension.toLowerCase != '.png'
```
to
```
fileExtension.toLowerCase() != '.png'
```