### PR TITLE
Bug Fixes for IOS (unable to fetch image path after taking a screenshot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Fork Note:  This uses some minor modifications of my own combined with the work of Tommy-Carlos Williams and ThalesValentim to return the absolute path of the image in IOS, with a semi-unique filename.  Usage remains the same.  Essentially, it has been brought inline with the android version. It now supports latest cordova version
+### Fork Note:  This uses some minor modifications of my own combined with the work of Tommy-Carlos Williams and ThalesValentim to return the absolute path of the image in IOS, with a semi-unique filename.  Usage remains the same.  Essentially, it has been brought inline with the android version. It now supports latest cordova version on both android and ios.
 
 Canvas2ImagePlugin
 ============

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ On Android platforms you can change the format of the saved files (png/jpg) and 
 
 See an example project using it here: [https://github.com/devgeeks/Canvas2ImageDemo](https://github.com/devgeeks/Canvas2ImageDemo) - note: this app does not work in wp8.
 
+Note : now support latest cordova versions on both android and ios
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Fork Note:  This uses some minor modifications of my own combined with the work of Tommy-Carlos Williams and ThalesValentim to return the absolute path of the image in IOS, with a semi-unique filename.  Usage remains the same.  Essentially, it has been brought inline with the android version.
+### Fork Note:  This uses some minor modifications of my own combined with the work of Tommy-Carlos Williams and ThalesValentim to return the absolute path of the image in IOS, with a semi-unique filename.  Usage remains the same.  Essentially, it has been brought inline with the android version. It now supports latest cordova version
 
 Canvas2ImagePlugin
 ============

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ On Android platforms you can change the format of the saved files (png/jpg) and 
 
 See an example project using it here: [https://github.com/devgeeks/Canvas2ImageDemo](https://github.com/devgeeks/Canvas2ImageDemo) - note: this app does not work in wp8.
 
-Note : now support latest cordova versions on both android and ios
+
 Installation
 ------------
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "canvas2imageplugin",
+  "version": "0.7.2",
+  "description": "Canvas2ImagePlugin\r ============",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gurdaan/Canvas2ImagePlugin.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gurdaan/Canvas2ImagePlugin/issues"
+  },
+  "homepage": "https://github.com/gurdaan/Canvas2ImagePlugin#readme"
+}

--- a/src/ios/Canvas2ImagePlugin.m
+++ b/src/ios/Canvas2ImagePlugin.m
@@ -25,7 +25,7 @@
                || [[extension lowercaseString] isEqualToString:@"jpg"] || [[extension lowercaseString] isEqualToString:@"jpeg"]) {
         [UIImageJPEGRepresentation(image, quality) writeToFile:[directoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", imageName, @"jpg"]] options:NSAtomicWrite error:nil];
     } else {
-        ALog(@"Image Save Failed\nExtension: (%@) is not recognized, use (PNG/JPG)", extension);
+        NSLog(@"Image Save Failed\nExtension: (%@) is not recognized, use (PNG/JPG)", extension);
     }
 }
 
@@ -38,7 +38,8 @@
     NSString *dateString = [dateFormatter stringFromDate:date];
 
     self.latestCommand = command;
-    NSData* imageData = [NSData dataFromBase64String:[command.arguments objectAtIndex:0]];
+   // NSData* imageData = [NSData dataFromBase64String:[command.arguments objectAtIndex:0]];
+    NSData *imageData = [[NSData alloc] initWithBase64EncodedString:[command.arguments objectAtIndex:0] options:0];
     
     UIImage* image = [[[UIImage alloc] initWithData:imageData] autorelease];
 


### PR DESCRIPTION
The following changes have been made to update the repository

1. Inclusion of package.json in the repository so that it can be cloned in higher versions of cordova. Earlier versions used to give an error of "unable to clone the repository, no such repository exists" while cloning on cordova version 8.x

2.  replaced Alog with NSlog

3. Replaced deprecated function call
"NSData* imageData = [NSData dataFromBase64String:[command.arguments objectAtIndex:0]];"
with 
" NSData *imageData = [[NSData alloc] initWithBase64EncodedString:[command.arguments objectAtIndex:0] options:0];" as the former way of writing is now deprecated.

4. Changes in README.md 